### PR TITLE
docker/android-base: simpler Dockerfile

### DIFF
--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -3,18 +3,18 @@ FROM java:openjdk-6-jdk
 ENV ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz"
 ENV ANDROID_SDK_COMPONENTS="platform-tools,build-tools-21.1.2,android-21,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21"
 ENV ANDROID_HOME=/usr/local/android-sdk-linux
+ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-bin.zip
 
 # Dependencies
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven
-RUN curl -L http://services.gradle.org/distributions/gradle-2.2.1-bin.zip -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
+RUN curl -L ${GRADLE_URL} -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
 ENV GRADLE_HOME /usr/local/gradle-2.2.1
 
 # Download and untar SDK
 RUN curl -L ${ANDROID_SDK_URL} | tar xz -C /usr/local
 
-
 # Install Android SDK components
-RUN echo y | $ANDROID_HOME/tools/android update sdk --no-ui --all --filter ${ANDROID_SDK_COMPONENTS}
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter ${ANDROID_SDK_COMPONENTS}
 
 # Path
-ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$GRADLE_HOME/bin
+ENV PATH $PATH:${ANDROID_HOME}/tools:$ANDROID_HOME/platform-tools:${GRADLE_HOME}/bin

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -6,7 +6,7 @@ ENV ANDROID_HOME=/usr/local/android-sdk-linux
 ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-bin.zip
 
 # Dependencies
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven
+RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven --no-recommends
 RUN curl -L ${GRADLE_URL} -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
 ENV GRADLE_HOME /usr/local/gradle-2.2.1
 

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Dependencies
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven --no-install-recommends
-ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-all.zip
 RUN curl -L ${GRADLE_URL} -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
 ENV GRADLE_HOME /usr/local/gradle-2.2.1
 

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -1,20 +1,21 @@
 FROM java:openjdk-6-jdk
 
-ENV ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz"
-ENV ANDROID_SDK_COMPONENTS="platform-tools,build-tools-21.1.2,android-21,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21"
-ENV ANDROID_HOME=/usr/local/android-sdk-linux
-ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Dependencies
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven --no-recommends
+RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven --no-install-recommends
+ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-bin.zip
 RUN curl -L ${GRADLE_URL} -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
 ENV GRADLE_HOME /usr/local/gradle-2.2.1
 
 # Download and untar SDK
+ENV ANDROID_SDK_URL=http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz
 RUN curl -L ${ANDROID_SDK_URL} | tar xz -C /usr/local
+ENV ANDROID_HOME=/usr/local/android-sdk-linux
 
 # Install Android SDK components
-RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter ${ANDROID_SDK_COMPONENTS}
+ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_COMPONENTS}"
 
 # Path
 ENV PATH $PATH:${ANDROID_HOME}/tools:$ANDROID_HOME/platform-tools:${GRADLE_HOME}/bin

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-6-jdk
+FROM java:jdk
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -1,59 +1,20 @@
-FROM ubuntu:14.04
+FROM java:openjdk-6-jdk
 
-ENV HOME="/home/vagrant"
-ENV SDK_LINK="http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz"
-ENV TAR_LOC="$HOME/android-sdk.tgz"
-ENV SDK_LOC="$HOME/Android/Sdk"
+ENV ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz"
+ENV ANDROID_SDK_COMPONENTS="platform-tools,build-tools-21.1.2,android-21,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21"
+ENV ANDROID_HOME=/usr/local/android-sdk-linux
 
 # Dependencies
-RUN apt-get update && \
-    dpkg --add-architecture i386 && \
-    apt-get install -y python-software-properties build-essential  zlib1g-dev libncurses5-dev lib32ncurses5-dev && \
-    apt-get install -y git wget unzip && \
-    apt-get install -y default-jdk
+RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven
+RUN curl -L http://services.gradle.org/distributions/gradle-2.2.1-bin.zip -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
+ENV GRADLE_HOME /usr/local/gradle-2.2.1
 
-# Download and unzip SDK, then clean up
-RUN echo "Downloading SDK to $TAR_LOC" && \
-    mkdir -p $HOME && \
-    wget $SDK_LINK -O $TAR_LOC  && \
-    echo "Unzipping SDK to $SDK_LOC"  && \
-    mkdir -p $SDK_LOC  && \
-    tar -xvf $TAR_LOC -C $SDK_LOC --strip-components=1 && \
-    echo "Cleaning up" && \
-    rm $TAR_LOC
+# Download and untar SDK
+RUN curl -L ${ANDROID_SDK_URL} | tar xz -C /usr/local
+
 
 # Install Android SDK components
-RUN echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter build-tools-21.1.2 && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter platform-tools && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter android-21 && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter extra-android-support && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter extra-google-google_play_services && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter extra-google-m2repository && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter extra-android-m2repository && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter source-21 && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter addon-google_apis-google-21 && \
-    echo y | $SDK_LOC/tools/android update sdk --no-ui --all --filter sys-img-x86-addon-google_apis-google-21
-
-# 1000 is the default vagrant uid/gid
-RUN export uid=1000 gid=1000 && \
-    mkdir -p $HOME && \
-    mkdir -p /etc/sudoers.d && \
-    echo "vagrant:x:${uid}:${gid}:Vagrant,,,:/home/vagrant:/bin/bash" >> /etc/passwd && \
-    echo "vagrant:x:${uid}:" >> /etc/group && \
-    echo "vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant && \
-    chmod 0440 /etc/sudoers.d/vagrant && \
-    chown ${uid}:${gid} -R $HOME
-
-# Set SDK Permissions
-RUN echo "Setting SDK permissions" && \
-    chown -R vagrant: "$HOME/Android"
-
-# ADB is 32-bit
-RUN apt-get update && \
-    apt-get install -y libncurses5:i386 libstdc++6:i386 zlib1g:i386
+RUN echo y | $ANDROID_HOME/tools/android update sdk --no-ui --all --filter ${ANDROID_SDK_COMPONENTS}
 
 # Path
-ENV PATH=$PATH:$HOME/Android/Sdk/tools
-ENV PATH=$PATH:$HOME/Android/Sdk/platform-tools
-
-USER vagrant
+ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$GRADLE_HOME/bin

--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -L ${ANDROID_SDK_URL} | tar xz -C /usr/local
 ENV ANDROID_HOME=/usr/local/android-sdk-linux
 
 # Install Android SDK components
-ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
+ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support
 RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_COMPONENTS}"
 
 # Path

--- a/docker/android-studio/Dockerfile
+++ b/docker/android-studio/Dockerfile
@@ -7,10 +7,6 @@ ENV STUDIO_LINK="https://dl.google.com/dl/android/studio/ide-zips/1.0.1/android-
 ENV ZIP_LOC="$HOME/android-studio.zip"
 ENV STUDIO_LOC="$HOME/android-studio"
 
-# Dependencies
-RUN apt-get update && \
-    apt-get install -y wget unzip
-
 # Download and Unzip Android Studio, then delete the zip
 RUN echo "Downloading Android Studio" && \
     mkdir -p $HOME && \
@@ -28,6 +24,10 @@ RUN export uid=1000 gid=1000 && \
     echo "vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant && \
     chmod 0440 /etc/sudoers.d/vagrant && \
     chown ${uid}:${gid} -R /home/vagrant
+
+# Install extra Android SDK components
+ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_COMPONENTS}"
 
 # Run Android Studio
 USER vagrant

--- a/docker/android-studio/Dockerfile
+++ b/docker/android-studio/Dockerfile
@@ -26,8 +26,8 @@ RUN export uid=1000 gid=1000 && \
     chown ${uid}:${gid} -R /home/vagrant
 
 # Install extra Android SDK components
-ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support
-RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_COMPONENTS}"
+ENV ANDROID_SDK_EXTRA_COMPONENTS=extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_EXTRA_COMPONENTS}"
 
 # Run Android Studio
 USER vagrant

--- a/docker/android-studio/Dockerfile
+++ b/docker/android-studio/Dockerfile
@@ -1,34 +1,16 @@
 FROM samtstern/android-base
 
-USER root
-
-ENV HOME="/home/vagrant"
-ENV STUDIO_LINK="https://dl.google.com/dl/android/studio/ide-zips/1.0.1/android-studio-ide-135.1641136-linux.zip"
-ENV ZIP_LOC="$HOME/android-studio.zip"
-ENV STUDIO_LOC="$HOME/android-studio"
-
-# Download and Unzip Android Studio, then delete the zip
-RUN echo "Downloading Android Studio" && \
-    mkdir -p $HOME && \
-    wget $STUDIO_LINK -O $ZIP_LOC && \
-    echo "Unzipping Android Studio" && \
-    unzip -d $STUDIO_LOC $ZIP_LOC && \
-    echo "Cleaning up..." && \
-    rm $ZIP_LOC
-
-# 1000 is the default vagrant uid/gid
-RUN export uid=1000 gid=1000 && \
-    mkdir -p $HOME && \
-    echo "vagrant:x:${uid}:${gid}:Vagrant,,,:/home/vagrant:/bin/bash" >> /etc/passwd && \
-    echo "vagrant:x:${uid}:" >> /etc/group && \
-    echo "vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant && \
-    chmod 0440 /etc/sudoers.d/vagrant && \
-    chown ${uid}:${gid} -R /home/vagrant
+# Download and Unzip Android Studio
+ENV ANDROID_STUDIO_URL="https://dl.google.com/dl/android/studio/ide-zips/1.0.1/android-studio-ide-135.1641136-linux.zip"
+RUN curl -L ${ANDROID_STUDIO_URL} -o /tmp/android-studio-ide.zip && unzip /tmp/android-studio-ide.zip -d /usr/local && rm android-studio-ide.zip
+ENV ANDROID_STUDIO_HOME=/usr/local/android-studio
 
 # Install extra Android SDK components
 ENV ANDROID_SDK_EXTRA_COMPONENTS=extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
 RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_EXTRA_COMPONENTS}"
 
-# Run Android Studio
-USER vagrant
-CMD sh $HOME/android-studio/android-studio/bin/studio.sh & /bin/bash
+# Path
+ENV PATH $PATH:${ANDROID_STUDIO_HOME}/bin
+
+# Set Android Studio entrypoint
+ENTRYPOINT studio.sh


### PR DESCRIPTION
- use java:openjdk-6-jdk
- use curl
- remove Vagrant user
- add gradle and ant
- install in `/usr/local`
- set `ANDROID_HOME`
