### PR TITLE
docker/android-studio: create studio user and volume

### DIFF
--- a/docker/android-base/Dockerfile
+++ b/docker/android-base/Dockerfile
@@ -1,20 +1,20 @@
 FROM java:jdk
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 # Dependencies
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 ant maven --no-install-recommends
-ENV GRADLE_URL=http://services.gradle.org/distributions/gradle-2.2.1-all.zip
+ENV GRADLE_URL http://services.gradle.org/distributions/gradle-2.2.1-all.zip
 RUN curl -L ${GRADLE_URL} -o /tmp/gradle-2.2.1-all.zip && unzip /tmp/gradle-2.2.1-all.zip -d /usr/local && rm /tmp/gradle-2.2.1-all.zip
 ENV GRADLE_HOME /usr/local/gradle-2.2.1
 
 # Download and untar SDK
-ENV ANDROID_SDK_URL=http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz
+ENV ANDROID_SDK_URL http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz
 RUN curl -L ${ANDROID_SDK_URL} | tar xz -C /usr/local
-ENV ANDROID_HOME=/usr/local/android-sdk-linux
+ENV ANDROID_HOME /usr/local/android-sdk-linux
 
 # Install Android SDK components
-ENV ANDROID_SDK_COMPONENTS=platform-tools,build-tools-21.1.2,android-21,extra-android-support
+ENV ANDROID_SDK_COMPONENTS platform-tools,build-tools-21.1.2,android-21,extra-android-support
 RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_COMPONENTS}"
 
 # Path

--- a/docker/android-studio/Dockerfile
+++ b/docker/android-studio/Dockerfile
@@ -1,16 +1,21 @@
 FROM samtstern/android-base
 
 # Download and Unzip Android Studio
-ENV ANDROID_STUDIO_URL="https://dl.google.com/dl/android/studio/ide-zips/1.0.1/android-studio-ide-135.1641136-linux.zip"
+ENV ANDROID_STUDIO_URL https://dl.google.com/dl/android/studio/ide-zips/1.0.1/android-studio-ide-135.1641136-linux.zip
 RUN curl -L ${ANDROID_STUDIO_URL} -o /tmp/android-studio-ide.zip && unzip /tmp/android-studio-ide.zip -d /usr/local && rm /tmp/android-studio-ide.zip
-ENV ANDROID_STUDIO_HOME=/usr/local/android-studio
+ENV ANDROID_STUDIO_HOME /usr/local/android-studio
 
-# Install extra Android SDK components
-ENV ANDROID_SDK_EXTRA_COMPONENTS=extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
+# Install extra Android SDK
+ENV ANDROID_SDK_EXTRA_COMPONENTS extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,source-21,addon-google_apis-google-21,sys-img-x86-addon-google_apis-google-21
 RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter "${ANDROID_SDK_EXTRA_COMPONENTS}"
+
+# Create studio user and home volume
+RUN useradd -u 1000 -d /home/studio -s /sbin/nologin -m studio
+VOLUME /home/studio
 
 # Path
 ENV PATH $PATH:${ANDROID_STUDIO_HOME}/bin
 
 # Set Android Studio entrypoint
+USER studio
 ENTRYPOINT studio.sh


### PR DESCRIPTION
This fixes #26 without requiring oracle jdk.
